### PR TITLE
【其他】组件 github 库搭建

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -125,22 +125,9 @@ module.exports = function(config) {
       require("karma-coverage-istanbul-reporter"),
       require("istanbul-instrumenter-loader"),
       require('karma-jasmine'),
-      require('karma-phantomjs-launcher'),
     ],
-    browsers: ['PhantomJS_custom', 'ChromeHeadless'],
+    browsers: ['ChromeHeadless'],
     customLaunchers: {
-      'PhantomJS_custom': {
-        base: 'PhantomJS',
-        options: {
-          windowName: 'my-window',
-          settings: {
-            webSecurityEnabled: false
-          },
-        },
-        flags: ['--load-images=true'],
-        debug: true
-      },
-
       ChromeHeadless: {
         base: 'Chrome',
         flags: [
@@ -151,10 +138,6 @@ module.exports = function(config) {
           '--remote-debugging-port=9222',
         ],
       }
-    },
-    phantomjsLauncher: {
-      // Have phantomjs exit if a ResourceError is encountered (useful if karma exits without killing phantom)
-      exitOnResourceError: true
     },
   });
 };

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "karma-jasmine": "^2.0.1",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-phantomjs-launcher": "^1.0.4",
     "karma-requirejs": "^1.1.0",
     "karma-webpack": "^3.0.5",
     "less": "^3.9.0",


### PR DESCRIPTION
# 移除单元测试环境 PhantomJS 

康哥 chrome 环境用不了的问题解决了，所以就直接把 PhantomJS 环境配置删除，因为 PhantomJS 环境需要下载一个文件没翻墙不好下下来，所以就统一用  chrome 环境