### PR TITLE
【表单组件】表单输入框布局

### DIFF
--- a/components/form/index.jsx
+++ b/components/form/index.jsx
@@ -261,13 +261,18 @@ const FormItem = (props) => {
               [`kant-wrapper-container-center`]: isEqual(mergewrapperAlign, 'center'),
             },
           );
+
+          const labelWidth =
+            'labelWidth' in props ?
+              props.labelWidth :
+              context.labelWidth;
           return (
             <div className={containerClassName}>
               {
                 props.label ?
                   <div
                     className={labelWrapperClassName}
-                    style={{ width: getLabelWidth(props.labelWidth) }}
+                    style={{ width: getLabelWidth(labelWidth) }}
                   >
                     <label
                       htmlFor=""
@@ -338,6 +343,7 @@ FormItem.defaultProps = {
  * @param {String} [props.direction='row']                 FormItem排列方式 row | column
  * @param {Number|Object} [props.gutter]                   栅格间隔  gutter=15 | gutter={{ xs: 8 }}
  * @param {String} [props.labelAlign='right']              label标签对齐方式
+ * @param {String} [props.labelWidth='80px']               label标签默认宽度
  * @param {Boolean} [props.inlineLabel=false]              label标签宽度自适应
  * @param {String} [props.wrapperAlign='left']             wrapper标签对齐方式
  * @param {String} [props.locationRequired='beforeLabel']  必填标识位置
@@ -350,6 +356,7 @@ const FormLayout = (props) => {
     colon: props.colon,
     direction: props.direction,
     inlineLabel: props.inlineLabel,
+    labelWidth: props.labelWidth,
     labelAlign: props.labelAlign,
     wrapperAlign: props.wrapperAlign,
     locationRequired: props.locationRequired,
@@ -420,6 +427,7 @@ FormLayout.defaultProps = {
   direction: 'row',
   inlineLabel: false,
   labelAlign: 'right',
+  labelWidth: '80px',
   wrapperAlign: 'left',
   hideRequiredMark: false,
   locationRequired: 'beforeLabel',

--- a/components/form/style.less
+++ b/components/form/style.less
@@ -5,6 +5,7 @@
   align-items: flex-start;
   min-height: 40px;
   height: 100%;
+  width: 100%;
   padding-right: 12px;
   flex-direction: row;
 
@@ -17,6 +18,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    width: 100%;
 
     & .kant-label {
       position: relative;

--- a/components/input-number/style.less
+++ b/components/input-number/style.less
@@ -4,6 +4,7 @@
   display: inline-block;
   position: relative;
   white-space: nowrap;
+  width: 100%;
 
   & .kant-input-number-prefix {
     display: inline-flex;
@@ -53,6 +54,7 @@
 
   .kant-input-number {
     position: relative;
+    width: 100%;
   }
 
   .kant-input-number:hover + .kant-input-number-suffix {

--- a/stories/pages/form/Form.jsx
+++ b/stories/pages/form/Form.jsx
@@ -161,7 +161,7 @@ const InputFormLayoutByHorizontal = Form.create({ name: 'row-input' })(({ form }
       >
         {form.getFieldDecorator("unitNo", {
           rules: [{ required: true, message: "必填" }],
-        })(<InputNumber style={{ width: '100%' }} placeholder="单元" />)}
+        })(<InputNumber placeholder="单元" />)}
       </FormItem>
       <FormItem
         row={2}


### PR DESCRIPTION
- 表单样式调整
- 数字输入框样式调整
- 添加`FormLayout`组件参数 `labelWIdth`属性, 支持设置`FormItem`的`label`标签宽度